### PR TITLE
Update cpp to 17 standard

### DIFF
--- a/agario/dockers/cpp/Dockerfile
+++ b/agario/dockers/cpp/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:16.04
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
+RUN apt-get update -y && \
+    apt-get install -y clang-5.0 make
+
+COPY Makefile ./
+
 ENV COMPILED_FILE_PATH=/opt/client/a.out
-ENV SOLUTION_CODE_ENTRYPOINT=main.cpp
-ENV COMPILATION_COMMAND='g++ -m64 -pipe -O2 -std=c++11 -w -o $COMPILED_FILE_PATH $SOLUTION_CODE_PATH/main.cpp  2>&1 > /dev/null'
+ENV SOLUTION_CODE_PATH=/opt/client/solution/
+ENV COMPILATION_COMMAND='make 2>&1 > /dev/null'
 ENV RUN_COMMAND='/lib64/ld-linux-x86-64.so.2 $MOUNT_POINT'

--- a/agario/dockers/cpp/Dockerfile
+++ b/agario/dockers/cpp/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:16.04
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
-RUN apt-get update -y && \
-    apt-get install -y clang-5.0 make
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test  && \
+    apt-get update -y && \
+    apt-get install -y g++-7 make 
 
 COPY Makefile ./
 

--- a/agario/dockers/cpp/Dockerfile
+++ b/agario/dockers/cpp/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test  && \
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get update -y && \
     apt-get install -y g++-7 make 
 

--- a/agario/dockers/cpp/Makefile
+++ b/agario/dockers/cpp/Makefile
@@ -1,7 +1,7 @@
-CPPFLAGS=-std=c++17 -O3 -m64 -pipe -w
-CPP=clang++-5.0
+CXXFLAGS=-std=c++17 -O3 -m64 -pipe -w
+CXX=g++-7
 
 SRCS = $(shell find ${SOLUTION_CODE_PATH} -type f -name '*.cpp')
 
 all: ${SRCS}
-	${CPP} ${CPPFLAGS} -o ${COMPILED_FILE_PATH} ${SRCS}
+	${CXX} ${CXXFLAGS} -o ${COMPILED_FILE_PATH} ${SRCS}

--- a/agario/dockers/cpp/Makefile
+++ b/agario/dockers/cpp/Makefile
@@ -1,0 +1,7 @@
+CPPFLAGS=-std=c++17 -O3 -m64 -pipe -w
+CPP=clang++-5.0
+
+SRCS = $(shell find ${SOLUTION_CODE_PATH} -type f -name '*.cpp')
+
+all: ${SRCS}
+	${CPP} ${CPPFLAGS} -o ${COMPILED_FILE_PATH} ${SRCS}


### PR DESCRIPTION
Обновил стандарт до c++17, поскольку он полностью поддерживается версией клэнга из стандартного репозитория убунты. 
Для сборки используется `make` который на этапе компиляции собирает все исходники с расширением `.cpp` из иерархии папок начиная с `SOLUTION_CODE_PATH`.