### PR TITLE
Using pip3 for python 3

### DIFF
--- a/agario/dockers/python3/Dockerfile
+++ b/agario/dockers/python3/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
-RUN apt-get install -y python3 python3-pip && pip install -U numpy scipy cython scikit-learn tensorflow keras pandas
+RUN apt-get update && apt-get install -y python3 python3-pip && pip3 install -U numpy scipy cython scikit-learn tensorflow keras pandas
 
 ENV SOLUTION_CODE_ENTRYPOINT=main.py
 ENV SOLUTION_CODE_PATH=/opt/client/solution


### PR DESCRIPTION
С пакетом python3-pip ставится 'pip3' вместо 'pip'.
А без команды 'apt-get update' в самом начале, вообще ни один пакет не ставится.