### PR TITLE
Fix bug with command output formatting

### DIFF
--- a/agario/examples/csharp/main.cs
+++ b/agario/examples/csharp/main.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.IO;
  
@@ -12,7 +13,7 @@ public class Strategy
 			var data = Console.ReadLine();
             var parsed = JObject.Parse(data);
 			var command = onTick(parsed);
-			Console.WriteLine(command.ToString());
+			Console.WriteLine(command.ToString(Formatting.None));
     	}
     }
 


### PR DESCRIPTION
Simple JToken.ToString() without passing formatting options serializes json with indentation and line breaks, and that's unexpected.