### PR TITLE
Allow focus on viewport

### DIFF
--- a/agario/local_runner/mainwindow.ui
+++ b/agario/local_runner/mainwindow.ui
@@ -29,6 +29,9 @@
         <height>660</height>
        </size>
       </property>
+      <property name="focusPolicy">
+       <enum>Qt::StrongFocus</enum>
+      </property>
       <property name="styleSheet">
        <string notr="true"/>
       </property>


### PR DESCRIPTION
Otherwise focus could be on a button, so the space key event goes to the key but
not to the viewport