### PR TITLE
Опять правки движений около стен. На этот раз, надеюсь, финальные

### DIFF
--- a/agario/local_runner/entities/ejection.h
+++ b/agario/local_runner/entities/ejection.h
@@ -64,19 +64,26 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
+        bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;
+            changed = true;
         } else {
-            x = qMax(radius, qMin(max_x - radius, x + dx));
+            double new_x = qMax(radius, qMin(max_x - radius, x + dx));
+            changed |= (x != new_x);
+            x = new_x;
         }
         if (dB + dy < max_y && uB + dy > 0) {
             y += dy;
+            changed = true;
         } else {
-            y = qMax(radius, qMin(max_y - radius, y + dy));
+            double new_y = qMax(radius, qMin(max_y - radius, y + dy));
+            changed |= (y != new_y);
+            y = new_y;
         }
 
         speed = qMax(0.0, speed - Constants::instance().VISCOSITY);
-        return true;
+        return changed;
     }
 
 public:

--- a/agario/local_runner/entities/ejection.h
+++ b/agario/local_runner/entities/ejection.h
@@ -64,18 +64,19 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
-        bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;
-            changed = true;
+        } else {
+            x = qMax(radius, qMin(max_x - radius, x + dx));
         }
         if (dB + dy < max_y && uB + dy > 0) {
             y += dy;
-            changed = true;
+        } else {
+            y = qMax(radius, qMin(max_y - radius, y + dy));
         }
 
-        speed = std::max(0.0, speed - Constants::instance().VISCOSITY);
-        return changed;
+        speed = qMax(0.0, speed - Constants::instance().VISCOSITY);
+        return true;
     }
 
 public:

--- a/agario/local_runner/entities/ejection.h
+++ b/agario/local_runner/entities/ejection.h
@@ -58,29 +58,16 @@ public:
         if (speed == 0.0) {
             return false;
         }
-        double rB = x + radius, lB = x - radius;
-        double dB = y + radius, uB = y - radius;
-
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
-        bool changed = false;
-        if (rB + dx < max_x && lB + dx > 0) {
-            x += dx;
-            changed = true;
-        } else {
-            double new_x = qMax(radius, qMin(max_x - radius, x + dx));
-            changed |= (x != new_x);
-            x = new_x;
-        }
-        if (dB + dy < max_y && uB + dy > 0) {
-            y += dy;
-            changed = true;
-        } else {
-            double new_y = qMax(radius, qMin(max_y - radius, y + dy));
-            changed |= (y != new_y);
-            y = new_y;
-        }
+        double new_x = qMax(radius, qMin(max_x - radius, x + dx));
+        bool changed = (x != new_x);
+        x = new_x;
+
+        double new_y = qMax(radius, qMin(max_y - radius, y + dy));
+        changed |= (y != new_y);
+        y = new_y;
 
         speed = qMax(0.0, speed - Constants::instance().VISCOSITY);
         return changed;

--- a/agario/local_runner/entities/player.h
+++ b/agario/local_runner/entities/player.h
@@ -455,10 +455,8 @@ public:
         else {
             // долетаем до стенки
             double new_x = qMax(radius, qMin(max_x - radius, x + dx));
-            if (new_x != x) {
-                changed = true;
-                x = new_x;
-            }
+            changed |= (x != new_x);
+            x = new_x;
             // зануляем проекцию скорости по dx
             double speed_y = speed * qSin(angle);
             speed = qAbs(speed_y);
@@ -471,10 +469,8 @@ public:
         else {
             // долетаем до стенки
             double new_y = qMax(radius, qMin(max_y - radius, y + dy));
-            if (new_y != y) {
-                changed = true;
-                y = new_y;
-            }
+            changed |= (y != new_y);
+            y = new_y;
             // зануляем проекцию скорости по dy
             double speed_x = speed * qCos(angle);
             speed = qAbs(speed_x);

--- a/agario/local_runner/entities/player.h
+++ b/agario/local_runner/entities/player.h
@@ -444,12 +444,21 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
+        // мне кажется, что это changed надо удалить
+        // редкая ситуация, когда игрок стоит на месте.
+        // исключая speed == 0.0, если будут доделаны мёртвые игроки
+        bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;
+            changed = true;
         }
         else {
             // долетаем до стенки
-            x = qMax(radius, qMin(max_x - radius, x + dx));
+            double new_x = qMax(radius, qMin(max_x - radius, x + dx));
+            if (new_x != x) {
+                changed = true;
+                x = new_x;
+            }
             // зануляем проекцию скорости по dx
             double speed_y = speed * qSin(angle);
             speed = qAbs(speed_y);
@@ -457,10 +466,15 @@ public:
         }
         if (dB + dy < max_y && uB + dy > 0) {
             y += dy;
+            changed = true;
         }
         else {
             // долетаем до стенки
-            y = qMax(radius, qMin(max_y - radius, y + dy));
+            double new_y = qMax(radius, qMin(max_y - radius, y + dy));
+            if (new_y != y) {
+                changed = true;
+                y = new_y;
+            }
             // зануляем проекцию скорости по dy
             double speed_x = speed * qCos(angle);
             speed = qAbs(speed_x);
@@ -474,7 +488,7 @@ public:
         if (fuse_timer > 0) {
             fuse_timer--;
         }
-        return true;
+        return changed;
     }
 
     bool clear_fragments() {

--- a/agario/local_runner/entities/player.h
+++ b/agario/local_runner/entities/player.h
@@ -444,9 +444,6 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
-        // мне кажется, что это changed надо удалить
-        // редкая ситуация, когда игрок стоит на месте.
-        // исключая speed == 0.0, если будут доделаны мёртвые игроки
         bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;

--- a/agario/local_runner/entities/player.h
+++ b/agario/local_runner/entities/player.h
@@ -444,14 +444,12 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
-        bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;
-            changed = true;
         }
         else {
             // долетаем до стенки
-            x = qMax(.0, qMin((double)max_x, x + dx));
+            x = qMax(radius, qMin(max_x - radius, x + dx));
             // зануляем проекцию скорости по dx
             double speed_y = speed * qSin(angle);
             speed = qAbs(speed_y);
@@ -459,11 +457,10 @@ public:
         }
         if (dB + dy < max_y && uB + dy > 0) {
             y += dy;
-            changed = true;
         }
         else {
             // долетаем до стенки
-            y = qMax(.0, qMin((double)max_y, y + dy));
+            y = qMax(radius, qMin(max_y - radius, y + dy));
             // зануляем проекцию скорости по dy
             double speed_x = speed * qCos(angle);
             speed = qAbs(speed_x);
@@ -477,7 +474,7 @@ public:
         if (fuse_timer > 0) {
             fuse_timer--;
         }
-        return changed;
+        return true;
     }
 
     bool clear_fragments() {

--- a/agario/local_runner/entities/virus.h
+++ b/agario/local_runner/entities/virus.h
@@ -86,29 +86,16 @@ public:
         if (speed == 0.0) {
             return false;
         }
-        double rB = x + radius, lB = x - radius;
-        double dB = y + radius, uB = y - radius;
-
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
-        bool changed = false;
-        if (rB + dx < max_x && lB + dx > 0) {
-            x += dx;
-            changed = true;
-        } else {
-            double new_x = qMax(radius, qMin(max_x - radius, x + dx));
-            changed |= (x != new_x);
-            x = new_x;
-        }
-        if (dB + dy < max_y && uB + dy > 0) {
-            y += dy;
-            changed = true;
-        } else {
-            double new_y = qMax(radius, qMin(max_y - radius, y + dy));
-            changed |= (y != new_y);
-            y = new_y;
-        }
+        double new_x = qMax(radius, qMin(max_x - radius, x + dx));
+        bool changed = (x != new_x);
+        x = new_x;
+
+        double new_y = qMax(radius, qMin(max_y - radius, y + dy));
+        changed |= (y != new_y);
+        y = new_y;
 
         speed = qMax(0.0, speed - Constants::instance().VISCOSITY);
         return changed;

--- a/agario/local_runner/entities/virus.h
+++ b/agario/local_runner/entities/virus.h
@@ -92,19 +92,26 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
+        bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;
+            changed = true;
         } else {
-            x = qMax(radius, qMin(max_x - radius, x + dx));
+            double new_x = qMax(radius, qMin(max_x - radius, x + dx));
+            changed |= (x != new_x);
+            x = new_x;
         }
         if (dB + dy < max_y && uB + dy > 0) {
             y += dy;
+            changed = true;
         } else {
-            y = qMax(radius, qMin(max_y - radius, y + dy));
+            double new_y = qMax(radius, qMin(max_y - radius, y + dy));
+            changed |= (y != new_y);
+            y = new_y;
         }
 
-        speed = std::max(0.0, speed - Constants::instance().VISCOSITY);
-        return true;
+        speed = qMax(0.0, speed - Constants::instance().VISCOSITY);
+        return changed;
     }
 
     virtual QJsonObject toJson(bool mine=false) const {

--- a/agario/local_runner/entities/virus.h
+++ b/agario/local_runner/entities/virus.h
@@ -92,18 +92,19 @@ public:
         double dx = speed * qCos(angle);
         double dy = speed * qSin(angle);
 
-        bool changed = false;
         if (rB + dx < max_x && lB + dx > 0) {
             x += dx;
-            changed = true;
+        } else {
+            x = qMax(radius, qMin(max_x - radius, x + dx));
         }
         if (dB + dy < max_y && uB + dy > 0) {
             y += dy;
-            changed = true;
+        } else {
+            y = qMax(radius, qMin(max_y - radius, y + dy));
         }
 
         speed = std::max(0.0, speed - Constants::instance().VISCOSITY);
-        return changed;
+        return true;
     }
 
     virtual QJsonObject toJson(bool mine=false) const {


### PR DESCRIPTION
Изменения:
- убрал у ejection/virus флаг changed при движении. Если он движется, то единственный случай, когда будет не changed - это когда заехали в угол, но всё еще "летим"
- аналогично хотелось сделать для игрока, но пока changed там оставил. Нет смысла в этом флаге по причине постоянного движения игроков. Единственный разумный вариант - опять таки если игрок "зажался" в углу, или стратегия упала. Если будет доделано торможение стратегии при её падании

Также все движущиеся части теперь доезжают точно до стены, а не залипают от неё расстоянии, которое оставалось на шаге до предполагаемого "врезания"