### PR TITLE
security fix: insufficient entropy for random values

### DIFF
--- a/agario/local_runner/constants.h
+++ b/agario/local_runner/constants.h
@@ -37,7 +37,7 @@ public:
 
     int TICK_MS;                // 16 ms
     int BASE_TICK;              // every 50 ticks
-    quint64 SEED;               // qrand()
+    std::string SEED;           // from std::random_device
 
     double INERTION_FACTOR;     // 10.0
     double VISCOSITY;           // 0.25
@@ -53,6 +53,19 @@ public:
     static Constants &instance() {
         static Constants ins;
         return ins;
+    }
+
+    static std::string generate_seed(uint length = 10) {
+        std::random_device dev;
+        const std::string alphabet("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567");
+        std::uniform_int_distribution<> dist(0, static_cast<int>(alphabet.length() - 1));
+
+        std::string seed;
+        while (seed.length() < length) {
+            seed += alphabet[static_cast<uint>(dist(dev))];
+        }
+
+        return seed;
     }
 
     static Constants &initialize(const QProcessEnvironment &env) {
@@ -94,10 +107,8 @@ public:
         settings.endGroup();
         settings.sync();
 
-        QTime time = QTime::currentTime();
-        uint secs = QTime(0,0,0).secsTo(QTime::currentTime());
-        qsrand(secs * 1000 + time.msec());
-        c.SEED = env.value("SEED", QString::number(qrand())).toULongLong();
+        c.SEED = env.value("SEED", "").toStdString();
+
         return c;
     }
 

--- a/agario/local_runner/mainwindow.h
+++ b/agario/local_runner/mainwindow.h
@@ -7,6 +7,7 @@
 #include <QKeyEvent>
 #include <QMessageBox>
 
+#include "constants.h"
 #include "strategymodal.h"
 #include "mechanic.h"
 #include "ui_mainwindow.h"
@@ -42,8 +43,12 @@ public:
         this->setMouseTracking(true);
         this->setFixedSize(this->geometry().width(), this->geometry().height());
 
-        long T; time(&T);
-        ui->txt_seed->setText(QString::number(T));
+        if (Constants::instance().SEED.empty()) {
+            ui->txt_seed->setText(QString::fromStdString(Constants::generate_seed()));
+        } else {
+            ui->txt_seed->setText(QString::fromStdString(Constants::instance().SEED));
+        }
+
 
         connect(ui->btn_start, SIGNAL(pressed()), this, SLOT(init_game()));
         connect(ui->btn_stop, SIGNAL(pressed()), this, SLOT(clear_game()));
@@ -63,6 +68,8 @@ public:
         if (sm) delete sm;
     }
 
+
+
 public slots:
     void init_game() {
         if (is_paused) {
@@ -72,7 +79,7 @@ public slots:
         timerId = startTimer(Constants::instance().TICK_MS);
         ui->txt_ticks->setText("0");
 
-        int seed = ui->txt_seed->text().toInt();
+        std::string seed = ui->txt_seed->text().toStdString();
 
         mechanic->init_objects(seed, [this] (Player *player) {
             int pId = player->getId();

--- a/agario/local_runner/mechanic.h
+++ b/agario/local_runner/mechanic.h
@@ -51,9 +51,13 @@ public:
     }
 
 public:
-    void init_objects(quint64 seed, const StrategyGet &get_strategy) {
-        rand.seed(seed);
-        logger->init_file(QString::number(seed));
+    void init_objects(const std::string &seed, const StrategyGet &get_strategy) {
+        std::seed_seq seq(seed.begin(), seed.end());
+        rand.seed(seq);
+        std::array<uint, 1> simple_seeds;
+        seq.generate(simple_seeds.begin(), simple_seeds.end());
+        srand(simple_seeds[0]);
+        logger->init_file(QString::fromStdString(seed));
 
         add_player(START_PLAYER_SETS, get_strategy);
         add_food(START_FOOD_SETS);

--- a/agario/server_runner/constants.h
+++ b/agario/server_runner/constants.h
@@ -37,7 +37,7 @@ public:
 
     int TICK_MS;                // 16 ms
     int BASE_TICK;              // every 50 ticks
-    quint64 SEED;               // qrand()
+    std::string SEED;           // from std::random_device
 
     double INERTION_FACTOR;     // 10.0
     double VISCOSITY;           // 0.25
@@ -53,6 +53,19 @@ public:
     static Constants &instance() {
         static Constants ins;
         return ins;
+    }
+
+    static std::string generate_seed(uint length = 10) {
+        std::random_device dev;
+        const std::string alphabet("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567");
+        std::uniform_int_distribution<> dist(0, static_cast<int>(alphabet.length() - 1));
+
+        std::string seed;
+        while (seed.length() < length) {
+            seed += alphabet[static_cast<uint>(dist(dev))];
+        }
+
+        return seed;
     }
 
     static Constants &initialize(const QProcessEnvironment &env) {
@@ -94,10 +107,11 @@ public:
         settings.endGroup();
         settings.sync();
 
-        QTime time = QTime::currentTime();
-        uint secs = QTime(0,0,0).secsTo(QTime::currentTime());
-        qsrand(secs * 1000 + time.msec());
-        c.SEED = env.value("SEED", QString::number(qrand())).toULongLong();
+        c.SEED = env.value("SEED", "").toStdString();
+        if (c.SEED.empty()) {
+            c.SEED = generate_seed();
+        }
+
         return c;
     }
 

--- a/agario/server_runner/mechanic.h
+++ b/agario/server_runner/mechanic.h
@@ -51,9 +51,16 @@ public:
     }
 
 public:
-    void init_objects(quint64 seed, const StrategyGet &get_strategy) {
-        rand.seed(seed);
-        logger->init_file(QString::number(seed));
+    void init_objects(const std::string &seed, const StrategyGet &get_strategy) {
+        std::seed_seq seq(seed.begin(), seed.end());
+        rand.seed(seq);
+
+        std::array<uint, 1> simple_seeds;
+        seq.generate(simple_seeds.begin(), simple_seeds.end());
+        srand(simple_seeds[0]); // на всякий случай, если вдруг где-то когда-то будет использоваться обычный rand().
+                                // он используется, например, в умолчальной стратегии
+
+        logger->init_file(QString::number(simple_seeds[0]));
 
         add_player(START_PLAYER_SETS, get_strategy);
         add_food(START_FOOD_SETS);

--- a/agario/server_runner/tcp_server.h
+++ b/agario/server_runner/tcp_server.h
@@ -124,7 +124,7 @@ public slots:
         game_active = true;
         wait_timeout = 0;
 
-        quint64 seed = Constants::instance().SEED;
+        std::string seed = Constants::instance().SEED;
         mechanic->init_objects(seed, [] (Player*) -> Strategy* {
             return NULL;
         });


### PR DESCRIPTION
Из-за небольшого значения сида (реально используется только 32 бита, а то и того меньше) возможно сбрутить сид за разумное время работы стратегии, зная местоположение игрока и вирусов.
Для этого был изменен тип сида с quint64 (который на самом деле, похоже, использовал только младшие 32 бита) на std::string, чтобы можно было проинициализировать его совершенно произвольным бинарником, например, из /dev/urandom . также в коде приведен пример, как это можно сделать непосредственно на с++ stl (функция generate_seed) с использованием random_device, что в теории должно генерировать "безопасное" (непредсказуемое) значение.

Также, был проинициализирован стандартный сишный random-generator, в частности он используется в стратегии по-умолчанию, для выполнения split-а, [файл strategies/strategy.h](https://github.com/MailRuChamps/miniaicups/blob/88b8670ebec9fc11925c7d9c11847dabfdc11b7e/agario/local_runner/strategies/strategy.h#L39), из-за чего игры с одинаковым сидом совпадали не полностью