### PR TITLE
Поддержка многопоточности в CPP11, CPP17

### DIFF
--- a/agario/dockers/cpp11/Dockerfile
+++ b/agario/dockers/cpp11/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
 ENV COMPILED_FILE_PATH=/opt/client/a.out
 ENV SOLUTION_CODE_ENTRYPOINT=main.cpp
-ENV COMPILATION_COMMAND='g++ -m64 -pipe -O2 -std=c++11 -w -o $COMPILED_FILE_PATH $SOLUTION_CODE_PATH/main.cpp  2>&1 > /dev/null'
+ENV COMPILATION_COMMAND='g++ -m64 -pipe -O2 -std=c++11 -pthread -w -o $COMPILED_FILE_PATH $SOLUTION_CODE_PATH/main.cpp  2>&1 > /dev/null'
 ENV RUN_COMMAND='/lib64/ld-linux-x86-64.so.2 $MOUNT_POINT'
 
 COPY ./nlohmann ./nlohmann

--- a/agario/dockers/cpp17/Dockerfile
+++ b/agario/dockers/cpp17/Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:16.04
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+RUN \
     apt-get update -y && \
-    apt-get install -y g++-7 make 
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+    apt-get update -y && \
+    apt-get install -y g++-7 make
 
 COPY Makefile ./
 COPY ./nlohmann ./nlohmann

--- a/agario/dockers/cpp17/Makefile
+++ b/agario/dockers/cpp17/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS=-std=c++17 -O3 -m64 -pipe -w
+CXXFLAGS=-std=c++17 -O3 -m64 -pipe -w -pthread
 CXX=g++-7
 
 SRCS = $(shell find ${SOLUTION_CODE_PATH} -type f -name '*.cpp')


### PR DESCRIPTION
Без этих правок не заиспользовать std::thread:
_main.cpp: undefined reference to `pthread_create'_