### PR TITLE
Fix scores

### DIFF
--- a/agario/local_runner/constants.h
+++ b/agario/local_runner/constants.h
@@ -208,7 +208,6 @@ const int SCORE_FOR_FOOD = 1;
 const int SCORE_FOR_PLAYER = 10;
 const int SCORE_FOR_LAST = 100;
 const int SCORE_FOR_BURST = 2;
-const int SCORE_FOR_EJECT = 0;
 
 // TCP Server
 const QString HOST = "0.0.0.0";

--- a/agario/local_runner/entities/player.h
+++ b/agario/local_runner/entities/player.h
@@ -373,7 +373,6 @@ public:
 
         mass -= EJECT_MASS;
         radius = mass2radius(mass);
-        score += SCORE_FOR_EJECT;
         return new_eject;
     }
 

--- a/agario/local_runner/entities/player.h
+++ b/agario/local_runner/entities/player.h
@@ -3,7 +3,7 @@
 
 #include "circle.h"
 #include "ejection.h"
-
+#include "scores.h"
 
 class Player : public Circle
 {
@@ -15,17 +15,17 @@ protected:
     double speed, angle;
     int fragmentId;
     int color;
-    int score;
+    Scores score;
     double vision_radius;
     double cmd_x, cmd_y;
 
 public:
-    explicit Player(int _id, double _x, double _y, double _radius, double _mass, const int fId=0) :
+    explicit Player(Scores strategy_scores, int _id, double _x, double _y, double _radius, double _mass, const int fId=0) :
         Circle(_id, _x, _y, _radius, _mass),
         is_fast(false),
         speed(0), angle(0),
         fragmentId(fId),
-        score(0),
+        score(strategy_scores),
         vision_radius(0),
         cmd_x(0), cmd_y(0)
     {
@@ -62,12 +62,6 @@ public:
 
     virtual bool is_player() const {
         return true;
-    }
-
-    int get_score() {
-        int _score = score;
-        score = 0;
-        return _score;
     }
 
     QPair<double, double> get_direct_norm() const {
@@ -235,7 +229,7 @@ public:
 
         for (int I = 0; I < new_frags_cnt; I++) {
             int new_fId = max_fId + I + 1;
-            Player *new_fragment = new Player(id, x, y, new_radius, new_mass, new_fId);
+            Player *new_fragment = new Player(score, id, x, y, new_radius, new_mass, new_fId);
             new_fragment->set_color(color);
             fragments.append(new_fragment);
 
@@ -266,7 +260,7 @@ public:
         double new_mass = mass / 2;
         double new_radius = mass2radius(new_mass);
 
-        Player *new_player = new Player(id, x, y, new_radius, new_mass, max_fId + 1);
+        Player *new_player = new Player(score, id, x, y, new_radius, new_mass, max_fId + 1);
         new_player->set_color(color);
         new_player->set_impulse(SPLIT_START_SPEED, angle);
 

--- a/agario/local_runner/entities/scores.h
+++ b/agario/local_runner/entities/scores.h
@@ -1,0 +1,42 @@
+#ifndef SCORES_H
+#define SCORES_H
+
+#include <memory>
+
+class Scores {
+public:
+    inline Scores();
+    inline Scores& operator +=(unsigned additionalScores);
+    inline operator unsigned() const;
+    /**
+     * @return количество очков, полученных с момента последнего вызова extractChanges() либо с момента
+     * конструирования (если extractChanges() еще не вызывался)
+     */
+    inline unsigned extract_changes();
+private:
+    std::shared_ptr<unsigned> scores;
+    std::shared_ptr<unsigned> scores_delta;
+};
+
+Scores::Scores()
+    :scores(std::make_shared<unsigned>(0u)),
+     scores_delta(std::make_shared<unsigned>(0u)) {
+}
+
+Scores& Scores::operator+=(unsigned additionalScores) {
+    *scores_delta += additionalScores;
+    return *this;
+}
+
+Scores::operator unsigned() const {
+    return (*scores) + (*scores_delta);
+}
+
+unsigned Scores::extract_changes() {
+    unsigned delta = *scores_delta;
+    *scores_delta = 0u;
+    (*scores) += delta;
+    return delta;
+}
+
+#endif //SCORES_H

--- a/agario/local_runner/local_runner.pro
+++ b/agario/local_runner/local_runner.pro
@@ -28,6 +28,7 @@ HEADERS  += mainwindow.h \
     strategies/strategy.h \
     strategies/bymouse.h \
     entities/ejection.h \
+    entities/scores.h \
     strategymodal.h \
     strategies/custom.h
 

--- a/agario/local_runner/mainwindow.h
+++ b/agario/local_runner/mainwindow.h
@@ -11,6 +11,7 @@
 #include "strategymodal.h"
 #include "mechanic.h"
 #include "ui_mainwindow.h"
+#include "entities/scores.h"
 
 namespace Ui {
     class MainWindow;
@@ -241,13 +242,13 @@ public:
     }
 
     void update_score() {
-        QMap<int, int> scores = mechanic->get_scores();
+        const QMap<int, Scores>& scores = mechanic->get_scores();
 
         ui->tableWidget->setSortingEnabled(false);
 
         for (int row = 0; row < ui->tableWidget->rowCount(); ++row) {
             int pId = ui->tableWidget->item(row, 0)->data(Qt::DisplayRole).toInt();
-            ui->tableWidget->item(row, 2)->setData(Qt::DisplayRole, scores.value(pId));
+            ui->tableWidget->item(row, 2)->setData(Qt::DisplayRole, int(scores.value(pId)));
         }
 
          ui->tableWidget->setSortingEnabled(true);

--- a/agario/local_runner/mechanic.h
+++ b/agario/local_runner/mechanic.h
@@ -175,7 +175,7 @@ public:
         burst_on_viruses();
 
         update_players_radius();
-        update_scores();
+        log_scores();
         split_viruses();
 
         if (tick % ADD_FOOD_DELAY == 0 && food_array.length() < MAX_GAME_FOOD) {
@@ -727,7 +727,7 @@ public:
         }
     }
 
-    void update_scores() {
+    void log_scores() {
 
         for (auto it = player_scores.begin(); it != player_scores.end(); ++it) {
             Scores& scores = it.value();

--- a/agario/local_runner/mechanic.h
+++ b/agario/local_runner/mechanic.h
@@ -12,6 +12,7 @@
 #include "entities/virus.h"
 #include "entities/player.h"
 #include "entities/ejection.h"
+#include "entities/scores.h"
 
 #include "strategies/strategy.h"
 #include "strategies/bymouse.h"
@@ -36,7 +37,7 @@ private:
     PlayerArray player_array;
     StrategyArray strategy_array;
     QMap<int, Direct> strategy_directs;
-    QMap<int, int> player_scores;
+    QMap<int, Scores> player_scores;
 
     std::mt19937_64 rand;
 
@@ -100,6 +101,7 @@ public:
             if (strategy) delete strategy;
         }
         strategy_array.clear();
+        player_scores.clear();
     }
 
     bool isSeenBySomeone(Circle *target, const QMap<int, bool> &player_vision){
@@ -201,7 +203,7 @@ public:
             return true;
         }
         else if (livingIds.length() == 1) {
-            int living_score = player_scores[livingIds[0]];
+            unsigned living_score = player_scores[livingIds[0]];
             for (int pId : player_scores.keys()) {
                 if (pId != livingIds[0] && player_scores[pId] >= living_score) {
                     return false;
@@ -245,7 +247,7 @@ public:
             logger->write_add_cmd(tick, player);
         }
         for (int pId : player_scores.keys()) {
-            logger->write_player_score(tick, pId, player_scores[pId]);
+            logger->write_player_score(tick, pId, int(player_scores[pId]));
         }
     }
 
@@ -313,7 +315,7 @@ public:
             if (! is_space_empty(_x, _y, PLAYER_RADIUS)) {
                 return;
             }
-            Player *new_player = new Player(id_counter, _x, _y, PLAYER_RADIUS, PLAYER_MASS);
+            Player *new_player = new Player(player_scores[id_counter], id_counter, _x, _y, PLAYER_RADIUS, PLAYER_MASS);
             player_array.append(new_player);
             new_player->update_by_mass(Constants::instance().GAME_WIDTH, Constants::instance().GAME_HEIGHT);
 
@@ -322,7 +324,6 @@ public:
             strategy_array.append(new_strategy);
 #endif
 
-            player_scores[id_counter] = 0;
             id_counter++;
             if (tick % Constants::instance().BASE_TICK != 0) {
                 logger->write_add_cmd(tick, new_player);
@@ -727,12 +728,12 @@ public:
     }
 
     void update_scores() {
-        for (Player *player : player_array) {
-            int score = player->get_score();
-            if (score > 0) {
-                int pId = player->getId();
-                player_scores[pId] += score;
-                logger->write_player_score(tick, pId, player_scores[pId]);
+
+        for (auto it = player_scores.begin(); it != player_scores.end(); ++it) {
+            Scores& scores = it.value();
+
+            if (scores.extract_changes() > 0) {
+                logger->write_player_score(tick, it.key(), int(scores));
             }
         }
     }
@@ -763,7 +764,7 @@ public:
         return player_scores[pId];
     }
 
-    QMap<int, int> get_scores() const {
+    const QMap<int, Scores>& get_scores() const {
         return player_scores;
     }
 };

--- a/agario/local_runner/server_runner.pro
+++ b/agario/local_runner/server_runner.pro
@@ -20,6 +20,7 @@ HEADERS  += mechanic.h \
     entities/virus.h \
     entities/player.h \
     entities/ejection.h \
+    entities/scores.h \
     tcp_server.h \
     tcp_connect.h
 


### PR DESCRIPTION
Выделена сущность Scores - очки стратегии, разделяемые между игроками-фрагментами, подконтрольными этой стратегии. Каждый объект типа Player имеет доступ к очкам стратегии.

При любом игровом действии, приводящем к начислению очков, очки начисляются непосредственно стратегии. Ранее очки записывались в данные фрагмента, "заработавшего" очки, а в конце хода из каждого фрагмента извлекались и записывались в карту очков. Проблема в том, что до конца хода фрагмент может и не дожить, в таких ситуациях очки пропадали.

**Внимание!** Ранее в лог очки, заработанные каждым фрагментом, писались раздельно (но без привязки к id фрагмента). Т.е. если в один тик фрагменты A1, A2 игрока с идентификатором P заработали 3 и 4 очка соответственно, то в лог выводилось две записи (P, 3) и (P, 4). Как можно было использовать эту информацию, кроме простого суммирования - не знаю. Теперь будет выведена только одна запись (P, 7). Без этой модификации сделать код чище и понятнее, на мой взгляд, было невозможно.

Полагаю, что сломаться ничего не должно, но прошу обратить пристальное внимание при ревью и тестах (см. Mechanic::update_scores() -> log_scores())