### PR TITLE
added clang-format

### DIFF
--- a/agario/local_runner/.clang-format
+++ b/agario/local_runner/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: WebKit
+IndentWidth: 4
+UseTab: Never
+BreakBeforeBraces: Custom
+BraceWrapping: {
+    AfterClass: 'true'
+}
+


### PR DESCRIPTION
Добавлен clang-format-файл для автоматического форматирования. Постарался сделать стиль, максимально похожий на то, что уже используется в проекте. Для применения файла, необходимо запускать `clang-format` с параметром `-style=file`, либо в IDE выбрать стиль "file". clang-format сам умеет находить "ближайший" по ФС .clang-format относительно текущей директории