### PR TITLE
Scala: added de-facto standard json library

### DIFF
--- a/paperio/dockers/scala/build.sbt
+++ b/paperio/dockers/scala/build.sbt
@@ -8,5 +8,6 @@ libraryDependencies += "com.rojoma" %% "rojoma-json-v3" % "3.8.0"
 libraryDependencies += "joda-time" % "joda-time" % "2.9.9"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.4"
 
 scalacOptions in Test ++= Seq("-Yrangepos")


### PR DESCRIPTION
More common json library, developed as part of most popular scala web framework ([11k stars versus 33 stars of current rojoma-json](https://github.com/playframework/playframework))