### PR TITLE
Fix bug in capture_voids_between_lines

### DIFF
--- a/paperio/local_runner/game_objects/territory.py
+++ b/paperio/local_runner/game_objects/territory.py
@@ -77,7 +77,7 @@ class Territory:
             for point in get_neighboring(cur):
                 if point in lines:
                     end_index = lines.index(point)
-                    path = lines[index:end_index]
+                    path = lines[index:end_index + 1]
                     if len(path) >= 8:
                         captured.extend(self._capture(path))
         return captured


### PR DESCRIPTION
Ошибка при определении "петель" в алгоритме присоединения траектории.
Пример траектории, которая должна, по идее, сработать как петля:
```
1 2 3
8   4
7 6 5
```
Но длина между первой и восьмой тут будет 7, а не 8 (из-за бага)