### PR TITLE
add Java 11 docker file

### DIFF
--- a/paperio/dockers/java11/Dockerfile
+++ b/paperio/dockers/java11/Dockerfile
@@ -1,0 +1,17 @@
+FROM stor.highloadcup.ru/aicups/paperio_base
+MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
+RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    apt-get update -y && \
+    apt-get install -y openjdk-11-jdk && \
+    apt-get install -y maven
+
+ENV SOLUTION_CODE_ENTRYPOINT=Main.java
+ENV COMPILED_FILE_PATH=/opt/client/javaStrategy.jar
+ENV SOLUTION_CODE_PATH=/opt/client/src/main/java/
+ENV COMPILATION_COMMAND='mvn package -q'
+ENV RUN_COMMAND='java -jar $MOUNT_POINT'
+
+COPY pom.xml ./
+RUN mkdir -p src/main/java && mvn dependency:go-offline && \
+    mvn package && \
+    rm -rf javaStrategy.jar target/classes/

--- a/paperio/dockers/java11/Dockerfile
+++ b/paperio/dockers/java11/Dockerfile
@@ -10,6 +10,7 @@ ENV COMPILED_FILE_PATH=/opt/client/javaStrategy.jar
 ENV SOLUTION_CODE_PATH=/opt/client/src/main/java/
 ENV COMPILATION_COMMAND='mvn package -q'
 ENV RUN_COMMAND='java -jar $MOUNT_POINT'
+ENV MAVEN_OPTS='-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit'
 
 COPY pom.xml ./
 RUN mkdir -p src/main/java && mvn dependency:go-offline && \

--- a/paperio/dockers/java11/pom.xml
+++ b/paperio/dockers/java11/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>JavaStrategy</groupId>
+    <artifactId>JavaStrategy</artifactId>
+    <version>1.0</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
+
+    <build>
+        <finalName>javaStrategy</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <outputDirectory>${basedir}</outputDirectory>
+                    <archive>
+                        <manifest>
+                            <mainClass>Main</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>${settings.localRepository}</classpathPrefix>
+                            <classpathLayoutType>repository</classpathLayoutType>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
Dockerfile добавляет ppa:openjdk-r/ppa репо, так как в базовых репо ubuntu 16.04 максимальная версия Java 9, а далее сначала устанавливает openjdk 11, а затем maven, в итоге `java -version` и `mvn --version` показывают, что всё работает на Java 11.

pom.xml настраивает наиболее новую версию maven-compiler-plugin на работу с Java 11, всё остальное как в Java 8/9 вариантах.

Полагаю, что если добавить Java 11 на основе этого ПР или чего-то подобного, то можно будет вообще убрать вариант Java 9 и оставить только 8 и 11.