### PR TITLE
CPP17 Dockerfile: добавлена C++ библиотека pytorch/libtorch

### DIFF
--- a/paperio/dockers/cpp17/Dockerfile
+++ b/paperio/dockers/cpp17/Dockerfile
@@ -8,6 +8,11 @@ RUN \
     apt-get update -y && \
     apt-get install -y g++-7 make cmake
 
+RUN \
+    curl https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-latest.zip -o /libtorch.zip && \
+    ln -s /usr /libtorch && unzip /libtorch.zip "libtorch/lib/*" "libtorch/share/*" "libtorch/include/*" -d / && \
+    rm -rf /libtorch.zip /libtorch
+
 COPY Makefile ./
 COPY ./nlohmann ./nlohmann
 


### PR DESCRIPTION
Протестировал что компиляция/линковка внутри контейнера работает с таким минимальным CMakeLists.txt:

```cmake
cmake_minimum_required(VERSION 3.0.0)

project(abc)

find_package(Torch REQUIRED)
add_executable(a a.cpp)
target_link_libraries(a PUBLIC ${TORCH_LIBRARIES} )
target_compile_options(a PUBLIC -std=c++17)
```