### PR TITLE
Update helpers.py is_intersect: manhattan dist

### DIFF
--- a/paperio/local_runner/helpers.py
+++ b/paperio/local_runner/helpers.py
@@ -197,4 +197,4 @@ def get_random_coordinates():
 def is_intersect(p1, p2, width=WIDTH):
     x1, y1 = p1
     x2, y2 = p2
-    return abs(x1 - x2) < width and abs(y1 - y2) < width
+    return abs(x1 - x2) + abs(y1 - y2) < width


### PR DESCRIPTION
Now is_intersect returns True if difference in any axis (x or y) between players less than width.
Thiat results to issue with double death in case when they pathes are perpendicular and both players start and end points (elementar cells, grid crosses) are valid.
Replacing condition to comparing width with manhattan dist makes this issue fixed.

Сейчас считается что есть столкновение, если разница по любой координате меньше 30.
В таком случае получаются ложные столкновения, когда оба игрока находятся в соседних узлах сетки (aka элементарных ячейках, кратных 30 -15), оба на своей территории. Затем первый игрок начинает двигаться ко второму, со своей территории на территорию второго, а второй уходит от столкновения в сторону. со своей территории на свою же.
Получается что второй игрок умирает двигаясь полностью по своей территории, это явно противоречит правилам.
[https://github.com/MailRuChamps/miniaicups/issues/295](https://github.com/MailRuChamps/miniaicups/issues/295)
Если заменить условие столкновения на (манхеттенская дистанция < width), то такой случай обработается ожидаемым образом, столкновения не будет, первый игрок начинает захват чужой территории, второй игрок находится на своей территории, в безопасности.