### PR TITLE
Added pypy3.6 dockerfile

### DIFF
--- a/paperio/dockers/pypy3.6/Dockerfile
+++ b/paperio/dockers/pypy3.6/Dockerfile
@@ -2,8 +2,8 @@ FROM stor.highloadcup.ru/aicups/paperio_base
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
 RUN add-apt-repository ppa:pypy/ppa -y && \
-    apt-get update && apt-get install pypy -y
+    apt-get update && apt-get install pypy3 -y
 
 ENV SOLUTION_CODE_ENTRYPOINT=main.py
 ENV SOLUTION_CODE_PATH=/opt/client/solution
-ENV RUN_COMMAND='pypy -u $SOLUTION_CODE_PATH/$SOLUTION_CODE_ENTRYPOINT'
+ENV RUN_COMMAND='pypy3 -u $SOLUTION_CODE_PATH/$SOLUTION_CODE_ENTRYPOINT'

--- a/paperio/dockers/pypy3.6/Dockerfile
+++ b/paperio/dockers/pypy3.6/Dockerfile
@@ -2,7 +2,10 @@ FROM stor.highloadcup.ru/aicups/paperio_base
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
 RUN add-apt-repository ppa:pypy/ppa -y && \
-    apt-get update && apt-get install pypy3 -y
+    apt-get update && apt-get install pypy3 -y && \
+    curl -sSL https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-linux64.tar.bz2 | tar xjv -C /usr/local --strip-components=1 && \
+    pypy3 -m ensurepip && pypy3 -m pip install --upgrade pip setuptools wheel && \
+    pypy3 -m pip install numpy && pypy3 -c 'import numpy'
 
 ENV SOLUTION_CODE_ENTRYPOINT=main.py
 ENV SOLUTION_CODE_PATH=/opt/client/solution

--- a/paperio/dockers/pypy3.6/Dockerfile
+++ b/paperio/dockers/pypy3.6/Dockerfile
@@ -1,0 +1,9 @@
+FROM stor.highloadcup.ru/aicups/paperio_base
+MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
+
+RUN add-apt-repository ppa:pypy/ppa -y && \
+    apt-get update && apt-get install pypy -y
+
+ENV SOLUTION_CODE_ENTRYPOINT=main.py
+ENV SOLUTION_CODE_PATH=/opt/client/solution
+ENV RUN_COMMAND='pypy -u $SOLUTION_CODE_PATH/$SOLUTION_CODE_ENTRYPOINT'

--- a/paperio/dockers/pypy3.6/Dockerfile
+++ b/paperio/dockers/pypy3.6/Dockerfile
@@ -1,9 +1,7 @@
 FROM stor.highloadcup.ru/aicups/paperio_base
 MAINTAINER Boris Kolganov <b.kolganov@corp.mail.ru>
 
-RUN add-apt-repository ppa:pypy/ppa -y && \
-    apt-get update && apt-get install pypy3 -y && \
-    curl -sSL https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-linux64.tar.bz2 | tar xjv -C /usr/local --strip-components=1 && \
+RUN curl -sSL https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-linux64.tar.bz2 | tar xjv -C /usr/local --strip-components=1 && \
     pypy3 -m ensurepip && pypy3 -m pip install --upgrade pip setuptools wheel && \
     pypy3 -m pip install numpy && pypy3 -c 'import numpy'
 


### PR DESCRIPTION
Очень долго провозился с добавлением еще сюда NumPyPy, но так и застрял на следующей ошибке: `SystemError: Cannot compile 'Python.h'. Perhaps you need to install python-dev|python-devel.`

Пробовал следующее:
```
apt-get update && apt-get install pypy git python-dev -y
curl -O https://bootstrap.pypa.io/get-pip.py
pypy get-pip.py
pypy -m pip install git+https://bitbucket.org/pypy/numpy.git
pypy -c 'import numpy'`
```

Так же брал `ppa:jonathonf/python-3.6` из докера Python3.6, пробовал от туда `-dev`, но всё равно... 

С остальными (scipy cython scikit-learn keras pandas tensorflow) даже не возился, ибо у них ошибки на [packages.pypy.org](http://packages.pypy.org) или вообще отсутствуют.

В общем было бы замечательно иметь хотя бы голый PyPy.