### PR TITLE
Update cpp17 image to g++9

### DIFF
--- a/paperio/dockers/cpp17/Dockerfile
+++ b/paperio/dockers/cpp17/Dockerfile
@@ -6,7 +6,7 @@ RUN \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get update -y && \
-    apt-get install -y g++-7 make cmake
+    apt-get install -y g++-9 make cmake
 
 COPY Makefile ./
 COPY ./nlohmann ./nlohmann

--- a/paperio/dockers/cpp17/Makefile
+++ b/paperio/dockers/cpp17/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS=-std=c++17 -O3 -m64 -pipe -w -pthread
-CXX=g++-7
+CXX=g++-9
 
 SRCS = $(shell find ${SOLUTION_CODE_PATH} -type f -name '*.cpp')
 


### PR DESCRIPTION
https://www.gnu.org/software/gcc/gcc-9/changes.html
> Runtime Library (libstdc++)
> Improved support for C++17, including:
> The C++17 implementation is no longer experimental.